### PR TITLE
Add config shutdown_timeout

### DIFF
--- a/lib/exrpc/mfa_lookup.ex
+++ b/lib/exrpc/mfa_lookup.ex
@@ -68,12 +68,14 @@ defmodule Exrpc.MFALookup do
       iex> Exrpc.MFALookup.to_list(lookup)
       [{Greeter, :hello, 1}, {Greeter, :goodbye, 1}]
   """
-  @spec to_list(t()) :: [mfa()]
+  @spec to_list(t()) :: [mfa()] | {:error, :invalid_mfa_lookup}
   def to_list({mfa2id, _} = _mfa_lookup) do
     mfa2id
     |> :ets.tab2list()
     |> Enum.sort_by(fn {_, id} -> id end)
     |> Enum.map(fn {fun, _} -> fun end)
+  rescue
+    ArgumentError -> {:error, :invalid_mfa_lookup}
   end
 
   @doc """
@@ -92,12 +94,14 @@ defmodule Exrpc.MFALookup do
       iex> Exrpc.MFALookup.mfa_to_id(lookup, {Greeter, :heyyyy, 1})
       nil
   """
-  @spec mfa_to_id(t(), mfa()) :: integer() | nil
+  @spec mfa_to_id(t(), mfa()) :: integer() | nil | {:error, :invalid_mfa_lookup}
   def mfa_to_id({mfa2id, _} = _mfa_lookup, {module_name, function_name, arity} = _mfa) do
     case :ets.lookup(mfa2id, {module_name, function_name, arity}) do
       [{_, id}] -> id
       [] -> nil
     end
+  rescue
+    ArgumentError -> {:error, :invalid_mfa_lookup}
   end
 
   def mfa_to_id(_, _), do: {:error, :invalid_mfa_lookup}
@@ -118,12 +122,14 @@ defmodule Exrpc.MFALookup do
       iex> Exrpc.MFALookup.id_to_mfa(lookup, 2)
       nil
   """
-  @spec id_to_mfa(t(), integer()) :: mfa() | nil
+  @spec id_to_mfa(t(), integer()) :: mfa() | nil | {:error, :invalid_mfa_lookup}
   def id_to_mfa({_, id2mfa} = _mfa_lookup, id) do
     case :ets.lookup(id2mfa, id) do
       [{_, {module_name, function_name, arity}}] -> {module_name, function_name, arity}
       [] -> nil
     end
+  rescue
+    ArgumentError -> {:error, :invalid_mfa_lookup}
   end
 
   def id_to_mfa(_, _), do: {:error, :invalid_mfa_lookup}

--- a/lib/exrpc/server/handler.ex
+++ b/lib/exrpc/server/handler.ex
@@ -52,13 +52,10 @@ defmodule Exrpc.Server.Handler do
   # Request handling and responding
 
   defp handle_and_respond(request, socket, mfa_lookup) do
-    response =
-      request
-      |> Request.decode()
-      |> handle_request(mfa_lookup)
-      |> Response.encode()
-
-    Socket.send(socket, response)
+    request
+    |> Request.decode()
+    |> handle_request(mfa_lookup)
+    |> maybe_send_response(socket)
   end
 
   defp handle_request(:ping, _) do
@@ -66,13 +63,19 @@ defmodule Exrpc.Server.Handler do
   end
 
   defp handle_request(:list, mfa_lookup) do
-    {:goodrpc, Exrpc.MFALookup.to_list(mfa_lookup)}
+    case Exrpc.MFALookup.to_list(mfa_lookup) do
+      list when is_list(list) -> {:goodrpc, list}
+      error -> error
+    end
   end
 
   defp handle_request({:apply, id, arg}, mfa_lookup) do
     arity = length(arg)
 
     case Exrpc.MFALookup.id_to_mfa(mfa_lookup, id) do
+      {:error, :invalid_mfa_lookup} = error ->
+        error
+
       {mod, fun, ^arity} ->
         try do
           result = apply(mod, fun, arg)
@@ -90,5 +93,11 @@ defmodule Exrpc.Server.Handler do
 
   defp handle_request(_, _) do
     {:badrpc, :invalid_request}
+  end
+
+  defp maybe_send_response({:error, :invalid_mfa_lookup} = error, _), do: error
+  defp maybe_send_response(response, socket) do
+    encoded = Response.encode(response)
+    Socket.send(socket, encoded)
   end
 end


### PR DESCRIPTION
Add new configuration shutdown_timeout. When there is existing connection, the process won't shutdown until timeout is reached. Sometimes we want to shut it down faster so I make it configurable. Thanks.